### PR TITLE
Fix Claude CLI installation URL in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ You need at least one CLI installed. For full council functionality, install all
 
 | CLI | Installation | Required |
 |-----|--------------|----------|
-| Claude | [claude.ai/code](https://claude.ai/code) | Yes |
+| Claude | [code.claude.com](https://code.claude.com/docs/en/setup) | Yes |
 | Codex | `npm install -g @openai/codex` | No |
 | Gemini | `npm install -g @google/gemini-cli` | No |
 
@@ -254,7 +254,7 @@ Run the test suite:
 Install the Claude Code CLI:
 
 ```bash
-# Visit https://claude.ai/code for installation instructions
+# Visit https://code.claude.com/docs/en/setup for installation instructions
 ```
 
 #### "Quorum not met"

--- a/commands/council-status.md
+++ b/commands/council-status.md
@@ -102,6 +102,6 @@ Previous Session:
 
 If any CLI is missing, provide installation instructions:
 
-- **Claude**: Visit https://claude.ai/code or run `npm install -g @anthropic-ai/claude-code`
+- **Claude**: Visit https://code.claude.com/docs/en/setup or run `npm install -g @anthropic-ai/claude-code`
 - **Codex**: Run `npm install -g @openai/codex`
 - **Gemini**: Run `npm install -g @google/gemini-cli`

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -8,7 +8,7 @@ This guide explains how to install the LLM Council plugin for Claude Code and ho
 
 - Claude Code installed and signed in (VS Code or JetBrains).
 - At least one CLI installed:
-  - **Required**: Claude CLI – see https://claude.ai/code
+  - **Required**: Claude CLI – see https://code.claude.com/docs/en/setup
   - **Optional**: `codex`, `gemini` for full multi-model council.
 - Public GitHub repository: `https://github.com/xrf9268-hue/llm-council-plugin.git`.
 

--- a/skills/council-orchestrator/EXAMPLES.md
+++ b/skills/council-orchestrator/EXAMPLES.md
@@ -340,7 +340,7 @@ Required: At least Claude CLI
 **Solution:**
 ```bash
 # Install Claude CLI
-# See: https://claude.ai/code
+# See: https://code.claude.com/docs/en/setup
 
 # Verify installation
 command -v claude || echo "Still not available"

--- a/skills/council-orchestrator/REFERENCE.md
+++ b/skills/council-orchestrator/REFERENCE.md
@@ -22,7 +22,7 @@ This document provides detailed bash implementation guidance for the LLM Council
 #### Claude CLI
 ```bash
 # Installation varies by platform
-# See: https://claude.ai/code
+# See: https://code.claude.com/docs/en/setup
 command -v claude || echo "Install required"
 ```
 

--- a/skills/council-orchestrator/scripts/query_claude.sh
+++ b/skills/council-orchestrator/scripts/query_claude.sh
@@ -33,7 +33,7 @@ PROMPT="$1"
 # Check if Claude CLI is available
 if ! command -v claude &> /dev/null; then
     echo "Error: claude CLI not found" >&2
-    echo "Install from: https://claude.ai/code" >&2
+    echo "Install from: https://code.claude.com/docs/en/setup" >&2
     exit 1
 fi
 

--- a/skills/council-orchestrator/scripts/run_parallel.sh
+++ b/skills/council-orchestrator/scripts/run_parallel.sh
@@ -42,7 +42,7 @@ council_progress 1 10
 # Ensure at least Claude is available
 if [[ "$CLAUDE_AVAILABLE" != "yes" ]]; then
     error_msg "Claude CLI is required but not available"
-    echo "Install from: https://claude.ai/code" >&2
+    echo "Install from: https://code.claude.com/docs/en/setup" >&2
     exit 1
 fi
 


### PR DESCRIPTION
Replace outdated https://claude.ai/code references with the correct official installation guide at https://code.claude.com/docs/en/setup.

Updated files:
- README.md (2 occurrences)
- docs/INSTALL.md
- commands/council-status.md
- skills/council-orchestrator/EXAMPLES.md
- skills/council-orchestrator/REFERENCE.md
- skills/council-orchestrator/scripts/query_claude.sh
- skills/council-orchestrator/scripts/run_parallel.sh