### PR TITLE
fix: increase Claude CLI timeout from 60s to 120s

### DIFF
--- a/skills/council-orchestrator/EXAMPLES.md
+++ b/skills/council-orchestrator/EXAMPLES.md
@@ -186,7 +186,7 @@ Displaying Claude's response directly:
 ## Scenario 4: Error Recovery - CLI Timeout
 
 ### Situation
-Claude and Codex respond normally, but Gemini times out after 60 seconds.
+Claude and Codex respond normally, but Gemini times out after 120 seconds.
 
 ### Output
 ```
@@ -198,11 +198,11 @@ Claude and Codex respond normally, but Gemini times out after 60 seconds.
   ⏳ Codex: consulting...
   ⏳ Gemini: consulting...
 
-  ✓ Claude: responded (12.3s)
-  ✓ Codex: responded (15.7s)
-  ⏳ Gemini: still waiting... (45s)
-  ⏳ Gemini: still waiting... (60s)
-  ✗ Gemini: timeout after 60 seconds
+  ✓ Claude: responded (42.3s)
+  ✓ Codex: responded (48.7s)
+  ⏳ Gemini: still waiting... (90s)
+  ⏳ Gemini: still waiting... (120s)
+  ✗ Gemini: timeout after 120 seconds
 
 Council Status: Partial failure (2/3 members responded)
 

--- a/skills/council-orchestrator/REFERENCE.md
+++ b/skills/council-orchestrator/REFERENCE.md
@@ -464,15 +464,15 @@ validate_output ".council/stage1_claude.txt" "Claude" || {
 - Rate limiting (check stderr for 429)
 - CLI bug or crash
 
-### Timeout (>60 seconds)
+### Timeout (>120 seconds)
 
 **Implementation:**
 ```bash
-timeout 60s ./scripts/query_claude.sh "$query" \
+timeout 120s ./scripts/query_claude.sh "$query" \
     > .council/stage1_claude.txt 2>&1 || {
     exit_code=$?
     if [[ $exit_code -eq 124 ]]; then
-        error_msg "Claude timed out after 60 seconds"
+        error_msg "Claude timed out after 120 seconds"
         mark_member_absent "Claude" "Timeout"
     fi
 }
@@ -480,7 +480,7 @@ timeout 60s ./scripts/query_claude.sh "$query" \
 
 **Configurable Timeout:**
 ```bash
-TIMEOUT_SECONDS="${COUNCIL_CLI_TIMEOUT:-60}"
+TIMEOUT_SECONDS="${COUNCIL_CLI_TIMEOUT:-120}"
 timeout "${TIMEOUT_SECONDS}s" ./scripts/query_claude.sh "$query"
 ```
 
@@ -510,7 +510,7 @@ check_stage1_quorum || {
 | `COUNCIL_DIR` | `.council` | Working directory for council files |
 | `COUNCIL_MIN_QUORUM` | `2` | Minimum responses required |
 | `COUNCIL_MAX_PROMPT_LENGTH` | `10000` | Maximum query length (chars) |
-| `COUNCIL_CLI_TIMEOUT` | `60` | CLI timeout (seconds) |
+| `COUNCIL_CLI_TIMEOUT` | `120` | CLI timeout (seconds) |
 | `COUNCIL_CONFIG_FILE` | `~/.council/config` | Config file location |
 
 ### Configuration File
@@ -528,7 +528,7 @@ timeout=120
 **Usage:**
 ```bash
 # Get config value
-timeout=$(config_get "timeout" "60")
+timeout=$(config_get "timeout" "120")
 
 # Set config value
 config_set "enabled_members" "claude,gemini"

--- a/skills/council-orchestrator/SKILL.md
+++ b/skills/council-orchestrator/SKILL.md
@@ -158,7 +158,7 @@ cat .council/final_report.md
 | **CLI missing** | Proceed with available members | See [quorum requirements](./REFERENCE.md#quorum-requirements) |
 | **Rate limit (429)** | Exponential backoff, retry once | [Rate limit handling](./REFERENCE.md#rate-limiting-http-429) |
 | **Empty output** | Mark member absent in report | [Empty output handling](./REFERENCE.md#empty-output) |
-| **Timeout (>60s)** | Terminate, mark absent | [Timeout configuration](./REFERENCE.md#timeout-60-seconds) |
+| **Timeout (>120s)** | Terminate, mark absent | [Timeout configuration](./REFERENCE.md#timeout-120-seconds) |
 | **Quorum failure** | Abort council session | [Quorum check](./REFERENCE.md#quorum-failure) |
 
 **Graceful Degradation:**

--- a/skills/council-orchestrator/scripts/query_claude.sh
+++ b/skills/council-orchestrator/scripts/query_claude.sh
@@ -10,7 +10,7 @@
 set -euo pipefail
 
 # Configuration
-TIMEOUT_SECONDS="${CLAUDE_TIMEOUT:-60}"
+TIMEOUT_SECONDS="${CLAUDE_TIMEOUT:-120}"
 MAX_RETRIES="${CLAUDE_MAX_RETRIES:-1}"
 
 # Find timeout command (macOS uses gtimeout from coreutils, Linux uses timeout)
@@ -71,7 +71,7 @@ query_claude() {
 
         exit_code=$cmd_result
 
-        # Check for rate limit (exit code may vary, but we handle retryable errors)
+        # Check for timeout and other errors (exit code may vary, but we handle retryable errors)
         if [[ $exit_code -eq 124 ]]; then
             echo "Warning: Claude CLI timed out after ${TIMEOUT_SECONDS}s" >&2
         elif [[ $exit_code -eq 1 ]]; then


### PR DESCRIPTION
Resolves #22

**Problem:**
Claude CLI consistently timed out at 60 seconds for complex queries requiring ~5000+ character responses, while Codex (120s) and Gemini (120s) completed successfully. This resulted in 2/3 quorum instead of full 3/3 participation.

**Root Cause:**
- Claude timeout: 60 seconds (insufficient)
- Codex timeout: 120 seconds (adequate)
- Gemini timeout: 120 seconds (adequate)

**Fix:**
1. Increased Claude's default timeout from 60s to 120s in query_claude.sh
2. Updated all documentation to reflect new 120s timeout
3. Maintained backward compatibility via CLAUDE_TIMEOUT env var

**Changed Files:**
- skills/council-orchestrator/scripts/query_claude.sh (line 13)
- skills/council-orchestrator/REFERENCE.md (timeout examples & config)
- skills/council-orchestrator/SKILL.md (error handling table)
- skills/council-orchestrator/EXAMPLES.md (timeout scenario)

**Testing:**
- All 20 tests passed (./tests/test_runner.sh)
- Environment variable override still works (CLAUDE_TIMEOUT)
- Consistent with Codex/Gemini timeout configuration

**Impact:**
- Complex queries now have adequate time to complete
- Full 3/3 quorum achievable for complex technical questions
- No breaking changes (env var override preserved)